### PR TITLE
feat: add computer control MCP integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ localagent providers
 - Provides search-grounded responses
 - Includes citations and sources
 
+### Computer Control MCP
+- Optional [computer-control-mcp](https://github.com/AB498/computer-control-mcp) server for mouse and keyboard automation
+- Install with `pip install computer-control-mcp`
+- Start the server with `computer-control-mcp`
+- Configure `mcp.computer_control` in `config/orchestration.yaml`
+
 ## Architecture
 
 LocalAgent is built on the UnifiedWorkflow orchestration system, providing:

--- a/app/orchestration/__init__.py
+++ b/app/orchestration/__init__.py
@@ -5,7 +5,7 @@ Complete 12-phase workflow execution system with agent orchestration
 
 from .agent_adapter import AgentProviderAdapter, AgentRequest, AgentResponse
 from .workflow_engine import WorkflowEngine, WorkflowExecution, PhaseStatus
-from .mcp_integration import OrchestrationMCP, MemoryMCP, RedisMCP
+from .mcp_integration import OrchestrationMCP, MemoryMCP, RedisMCP, ComputerControlMCP
 from .context_manager import ContextManager, ContextPackage, TokenCounter
 from .orchestration_integration import LocalAgentOrchestrator, create_orchestrator
 from .cli_interface import LocalAgentCLI, main as cli_main
@@ -32,6 +32,7 @@ __all__ = [
     # MCP components
     "MemoryMCP",
     "RedisMCP",
+    "ComputerControlMCP",
     
     # Utilities
     "TokenCounter",

--- a/app/orchestration/mcp_integration.py
+++ b/app/orchestration/mcp_integration.py
@@ -330,6 +330,36 @@ class RedisMCP:
         except Exception as e:
             return {'healthy': False, 'error': str(e)}
 
+
+class ComputerControlMCP:
+    """Manage external computer-control-mcp server"""
+
+    def __init__(self, config: Dict[str, Any]):
+        self.config = config
+        self.process: Optional[asyncio.subprocess.Process] = None
+        self.logger = logging.getLogger(__name__)
+
+    async def start(self) -> bool:
+        command = self.config.get('command', 'computer-control-mcp')
+        args = self.config.get('args', [])
+        try:
+            self.process = await asyncio.create_subprocess_exec(
+                command, *args,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            self.logger.info('Computer Control MCP server started')
+            return True
+        except Exception as e:
+            self.logger.error(f'Failed to start Computer Control MCP: {e}')
+            return False
+
+    async def stop(self) -> None:
+        if self.process:
+            self.process.terminate()
+            await self.process.wait()
+            self.logger.info('Computer Control MCP server stopped')
+
 class OrchestrationMCP:
     """
     Orchestration MCP for workflow management and agent coordination

--- a/config/orchestration.yaml
+++ b/config/orchestration.yaml
@@ -18,6 +18,8 @@ mcp:
   redis:
     redis_url: redis://localhost:6379
   memory: {}
+  computer_control:
+    command: computer-control-mcp
 
 providers:
   ollama:

--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -57,6 +57,7 @@ jupyter>=1.0.0
 # MCP integration
 websockets>=11.0.0
 jsonschema>=4.17.0
+computer-control-mcp>=0.3.0
 
 # Token counting
 tiktoken>=0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,9 @@ anthropic>=0.3.0  # For future Claude integration
 cryptography>=41.0.0
 keyring>=24.0.0
 
+# MCP servers
+computer-control-mcp>=0.3.0
+
 # Development
 pytest>=7.0.0
 pytest-asyncio>=0.21.0


### PR DESCRIPTION
## Summary
- document Computer Control MCP server usage
- add computer-control-mcp dependency and config
- implement ComputerControlMCP helper class

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'aioredis'; ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_68ae591667f483328e890f3ce291e4d6