### PR TITLE
feat: include AGENTS.md context in CLI

### DIFF
--- a/app/orchestration/README.md
+++ b/app/orchestration/README.md
@@ -140,6 +140,10 @@ python -m app.orchestration.cli_interface health
 python -m app.orchestration.cli_interface agents
 ```
 
+#### AGENTS.md Support
+
+The CLI automatically searches for `AGENTS.md` files in the current directory and its parents. Any instructions found are combined and injected into the `agents_md` field of the context sent to agents and workflows.
+
 ### Programmatic Usage
 
 ```python

--- a/app/orchestration/cli_interface.py
+++ b/app/orchestration/cli_interface.py
@@ -19,6 +19,22 @@ class LocalAgentCLI:
     
     def __init__(self):
         self.orchestrator: Optional[LocalAgentOrchestrator] = None
+
+    def _load_agents_context(self, start_path: Optional[Path] = None) -> Optional[str]:
+        """Collect AGENTS.md instructions from current and parent directories."""
+        start = (start_path or Path.cwd()).resolve()
+        directories = list(start.parents)[::-1] + [start]
+        contents: List[str] = []
+        for directory in directories:
+            agents_file = directory / "AGENTS.md"
+            if agents_file.exists():
+                try:
+                    contents.append(agents_file.read_text(encoding="utf-8"))
+                except Exception:
+                    continue
+        if contents:
+            return "\n\n".join(contents)
+        return None
         
     def create_parser(self) -> argparse.ArgumentParser:
         """Create the main argument parser"""
@@ -184,6 +200,10 @@ class LocalAgentCLI:
             context = {}
             if args.context:
                 context = json.loads(args.context)
+
+            agents_md = self._load_agents_context()
+            if agents_md:
+                context.setdefault('agents_md', agents_md)
             
             print(f"🚀 Starting 12-phase workflow...")
             print(f"📝 Prompt: {args.prompt}")
@@ -242,7 +262,10 @@ class LocalAgentCLI:
             context = {}
             if args.context:
                 context = json.loads(args.context)
-            
+            agents_md = self._load_agents_context()
+            if agents_md:
+                context.setdefault('agents_md', agents_md)
+
             print(f"🤖 Executing agent: {args.agent_type}")
             print(f"📝 Prompt: {args.prompt}")
             

--- a/tests/unit/test_cli_agents_context.py
+++ b/tests/unit/test_cli_agents_context.py
@@ -1,0 +1,27 @@
+import sys
+import types
+
+# Stub aioredis to avoid heavy dependency during tests
+sys.modules.setdefault("aioredis", types.ModuleType("aioredis"))
+
+from app.orchestration.cli_interface import LocalAgentCLI
+
+
+def test_load_agents_context(tmp_path, monkeypatch):
+    root_agents = tmp_path / "AGENTS.md"
+    root_agents.write_text("root instruction", encoding="utf-8")
+
+    subdir = tmp_path / "sub"
+    subdir.mkdir()
+    sub_agents = subdir / "AGENTS.md"
+    sub_agents.write_text("sub instruction", encoding="utf-8")
+
+    cli = LocalAgentCLI()
+    monkeypatch.chdir(subdir)
+
+    content = cli._load_agents_context()
+
+    assert "root instruction" in content
+    assert "sub instruction" in content
+    assert content.index("root instruction") < content.index("sub instruction")
+


### PR DESCRIPTION
## Summary
- load AGENTS.md files from current and parent directories
- pass combined instructions to workflow and agent commands
- document AGENTS.md support and add unit test

## Testing
- `PYTHONPATH=. pytest tests/unit/test_cli_agents_context.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b11ad1b5148332ad6e3c04b5181eda